### PR TITLE
fix: ajustes  video links from youtube classes

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
                     <div class="class-image">
                         <img src="img/jiu-jitsu.png" alt="Jiu-Jitsu">
                         <!-- Botão de vídeo - Substitua o data-video pelo link do seu vídeo do YouTube (embed) -->
-                        <div class="video-btn" data-video="https://www.youtube.com/watch?v=0QDgz6cD4LQ&pp=ygURYXVsYSBkZSBqaXUgaml0c3XSBwkJvgkBhyohjO8%3D">
+                        <div class="video-btn" data-video="https://www.youtube.com/embed/0QDgz6cD4LQ?si=A5iPnB_6LSnNuCM6">
                             <i class="fas fa-play"></i>
                         </div>
                     </div>
@@ -121,7 +121,7 @@
                     <div class="class-image">
                         <img src="img/muay-thai.png" alt="Muay Thai">
                         <!-- Botão de vídeo - Substitua o data-video pelo link do seu vídeo do YouTube (embed) -->
-                        <div class="video-btn" data-video="https://www.youtube.com/watch?v=v0IIDNUjHPg&pp=ygURYXVsYSBkZSBtdWF5IHRoYWk%3D">
+                        <div class="video-btn" data-video="https://www.youtube.com/embed/v0IIDNUjHPg?si=ecckm-c5_2zHAASa">
                             <i class="fas fa-play"></i>
                         </div>
                     </div>
@@ -135,7 +135,7 @@
                     <div class="class-image">
                         <img src="img/mma.png" alt="MMA">
                         <!-- Botão de vídeo - Substitua o data-video pelo link do seu vídeo do YouTube (embed) -->
-                        <div class="video-btn" data-video="https://www.youtube.com/watch?v=EedXzImhybs&pp=ygULYXVsYSBkZSBtbWE%3D">
+                        <div class="video-btn" data-video="https://www.youtube.com/embed/EedXzImhybs?si=mwnLQ5Ix2BtSDD1O">
                             <i class="fas fa-play"></i>
                         </div>
                     </div>


### PR DESCRIPTION
This pull request updates the video links for the "Nossas Modalidades" section in the `index.html` file. The changes replace standard YouTube URLs with embed-friendly URLs, ensuring proper embedding functionality for the videos.

Video link updates:

* Updated the Jiu-Jitsu video link to use an embed-friendly format. (`index.html`, [index.htmlL110-R110](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L110-R110))
* Updated the Muay Thai video link to use an embed-friendly format. (`index.html`, [index.htmlL124-R124](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L124-R124))
* Updated the MMA video link to use an embed-friendly format. (`index.html`, [index.htmlL138-R138](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L138-R138))